### PR TITLE
Modify theme properties to derive from keycloak base theme

### DIFF
--- a/login/theme.properties
+++ b/login/theme.properties
@@ -1,0 +1,2 @@
+parent=keycloak
+import=common/keycloak

--- a/theme.properties
+++ b/theme.properties
@@ -1,1 +1,0 @@
-parent=base


### PR DESCRIPTION
This PR makes the following changes:

- Move the `theme.properties` files under `/login` so that the properties will be applied only on login
- Modify the theme to inherit from `keycloak` theme instead of `base`